### PR TITLE
Remove unused outlets

### DIFF
--- a/ProcessingKitExample/ProcessingKitExample/BasicFunctions/EllipseSampleViewController.storyboard
+++ b/ProcessingKitExample/ProcessingKitExample/BasicFunctions/EllipseSampleViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SEC-GA-SGT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SEC-GA-SGT">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -35,7 +35,6 @@
                     </view>
                     <connections>
                         <outlet property="ellipseSampleView" destination="djM-U0-qnF" id="bsP-CC-iGw"/>
-                        <outlet property="particlesSampleView" destination="djM-U0-qnF" id="nFh-aw-DnE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lRX-j2-Vvs" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/ProcessingKitExample/ProcessingKitExample/BasicFunctions/TextSampleViewController.storyboard
+++ b/ProcessingKitExample/ProcessingKitExample/BasicFunctions/TextSampleViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SgQ-81-Nb7">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SgQ-81-Nb7">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -34,7 +34,6 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="particlesSampleView" destination="Sq9-OT-Qdk" id="jD6-fa-zUH"/>
                         <outlet property="textSampleView" destination="Sq9-OT-Qdk" id="1fj-xz-HIA"/>
                     </connections>
                 </viewController>


### PR DESCRIPTION
### 対象Issue

- ProcessingKitExampleの実行中にエラーで止まる #27

### 修正方針

ProcessingKitExampleを実行して Text と Ellipse の画面が表示されるようにする

### 具体的な変更点

- `EllipseSampleController.storyboard` の outlet から `particlesSampleView` との連携を除去
- `TextSampleController.storyboard` の outlet から `particlesSampleView` との連携を除去

### 確認方法

- ProcessingKitExample をビルドする
    - **Text** をタップする
    - **Ellipse** をタップする

### レビューを必要としているところ

- この変更で問題がなかったか確認してほしい
- 他にも同じような問題がないか確認してほしい
- 自分の環境でこれの修正がなぜ必要だったのか不明瞭のままなので知りたい