### PR TITLE
Fix link to ProcessingKit 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ProcessingKit written in Swift🐧 and you can write like [processing](https://g
 - iOS 10.0 or later
 - OSX 10.11 or later
 
-If you use Swift 3.x, try [ProcessingKit 0.6.0](https://github.com/ishkawa/APIKit/tree/2.0.5).
+If you use Swift 3.x, try [ProcessingKit 0.6.0](https://github.com/natmark/ProcessingKit/releases/tag/0.6.0).
 
 ## Usage
 1. Create custom class that inherits from ProcessingView


### PR DESCRIPTION
The link to ProcessingKit 0.6.0 pointed at APIKit 2.0.5. It points at the 0.6.0 release of ProcessingKit now.